### PR TITLE
Error importing due to missing extention

### DIFF
--- a/astetik/plots/world.py
+++ b/astetik/plots/world.py
@@ -12,7 +12,7 @@ from ..utils.exceptions import MissingImport
 from ..style.formats import _thousand_sep
 from ..utils.outliers import outliers
 
-shapefile = pkg_resources.resource_filename(__name__, '../extras/countries')
+shapefile = pkg_resources.resource_filename(__name__, '../extras/countries.shp')
 
 
 def world(data,

--- a/astetik/plots/world.py
+++ b/astetik/plots/world.py
@@ -12,7 +12,8 @@ from ..utils.exceptions import MissingImport
 from ..style.formats import _thousand_sep
 from ..utils.outliers import outliers
 
-shapefile = pkg_resources.resource_filename(__name__, '../extras/countries.shp')
+shapefile = pkg_resources.resource_filename(__name__,
+        '../extras/countries.shp'stetik/plots/world.py line 15)
 
 
 def world(data,

--- a/astetik/plots/world.py
+++ b/astetik/plots/world.py
@@ -13,7 +13,7 @@ from ..style.formats import _thousand_sep
 from ..utils.outliers import outliers
 
 shapefile = pkg_resources.resource_filename(__name__,
-        '../extras/countries.shp'stetik/plots/world.py line 15)
+                                            '../extras/countries.shp'stetik/plots/world.py line 15)
 
 
 def world(data,


### PR DESCRIPTION
Add missing .shp extention to plots/world.py:15, without it, astetik fails to load.